### PR TITLE
Fix minor bugs

### DIFF
--- a/R/fit.R
+++ b/R/fit.R
@@ -88,7 +88,13 @@ fitCausal <- function(dat, formulas=list(y~x, z~1, ~x),
     wh_cnt <- which(!disc)
     new_ord <- c(wh_cnt, wh_disc, length(forms))
     new_ord0 <- new_ord[-length(new_ord)]
-    dat[inCop] <- dat[inCop][new_ord0]
+    
+    
+    ord <- seq_len(ncol(dat))  
+    ord[match(inCop,names(dat))] <- ord[match(inCop,names(dat))[new_ord0]]
+    dat <- dat[,ord]
+               
+    # dat[inCop] <- dat[inCop][new_ord0]
     LHS <- LHS[new_ord0]
     forms <- forms[new_ord]
     family <- family[new_ord]

--- a/R/intialize.R
+++ b/R/intialize.R
@@ -149,7 +149,7 @@ initializeParams2 <- function(dat, formulas, family=rep(1,nv), link, init=FALSE,
     }
 
     if (only_masks) {
-      phi_m[family %in% 1:3] <- 1
+      phi_m[family[-length(family)] %in% 1:3] <- 1
     }
     else {
       ## pick mean and sd...

--- a/R/nll.R
+++ b/R/nll.R
@@ -210,7 +210,7 @@ nll2 <- function(theta, dat, mm, beta, phi, inCop, fam_cop=1,
 
 ll <- function(dat, mm, beta, phi, inCop, fam_cop=1,
                  family=rep(1,nc), link, par2=NULL, useC=TRUE,
-                exclude_Z = FALSE, outcome = "Y") {
+                exclude_Z = FALSE, outcome = "y") {
 
   if (missing(inCop)) inCop <- seq_along(dat)
 

--- a/R/nll.R
+++ b/R/nll.R
@@ -209,7 +209,8 @@ nll2 <- function(theta, dat, mm, beta, phi, inCop, fam_cop=1,
 
 
 ll <- function(dat, mm, beta, phi, inCop, fam_cop=1,
-                 family=rep(1,nc), link, par2=NULL, useC=TRUE) {
+                 family=rep(1,nc), link, par2=NULL, useC=TRUE,
+                exclude_Z = FALSE, outcome = "Y") {
 
   if (missing(inCop)) inCop <- seq_along(dat)
 
@@ -238,7 +239,7 @@ ll <- function(dat, mm, beta, phi, inCop, fam_cop=1,
   for (i in which(family != 5)) {
     tmp <- univarDens(dat[,i], eta[,i], phi=phi[i], family=family[i])
     log_den[,i] <- tmp$ld
-    dat_u[,i] <- tmp$u
+    dat_u[,i] <- pmax(pmin(tmp$u,1-1e-10),1e-10)
   }
   # wh_trunc = 0
   ## deal with discrete variables separately
@@ -307,7 +308,13 @@ ll <- function(dat, mm, beta, phi, inCop, fam_cop=1,
     cop <- log(causl::dfgmCopula(dat_u[,1], dat_u[,2], alpha=par[[1]]))
   }
 
-  out <- cop + rowSums(log_den)
+  if (exclude_Z == FALSE) {
+    out <- cop + rowSums(log_den)
+    
+  } else{
+    wh_y <- which(colnames(dat) == outcome)
+    out <- cop + log_den[,wh_y]
+  }
 
   out
 }


### PR DESCRIPTION
fitCausal: fixed the reordering step so that the actual variables do not get changed while reordering the columns
initialize: when creating the phi vector in the mask, won't create a placeholder for the copula
ll: added the option to not include marginal probabilities of Z in the log likelihood.
