### PR TITLE
D gcop fix

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -13,10 +13,6 @@ dGcop_sig <- function(x, sigma, logd = FALSE) {
     .Call(`_causl_dGcop_sig`, x, sigma, logd)
 }
 
-dGDcop2 <- function(x, sigma, trunc, logd = FALSE) {
-    .Call(`_causl_dGDcop2`, x, sigma, trunc, logd)
-}
-
 dGDcop <- function(x, sigma, trunc, logd = FALSE) {
     .Call(`_causl_dGDcop`, x, sigma, trunc, logd)
 }
@@ -27,5 +23,9 @@ dGDcop_sig <- function(x, sigma, trunc, logd = FALSE) {
 
 dGDcop2_sig <- function(x, sigma, eta, q, logd = FALSE) {
     .Call(`_causl_dGDcop2_sig`, x, sigma, eta, q, logd)
+}
+
+dGDcop2 <- function(x, sigma, eta, q, logd = FALSE) {
+    .Call(`_causl_dGDcop2`, x, sigma, eta, q, logd)
 }
 

--- a/R/copulas.R
+++ b/R/copulas.R
@@ -413,10 +413,9 @@ dGaussDiscCop2 <- function(x, m, Sigma, eta, log=FALSE, useC=TRUE) {
   }
   
   ## check if all sigma matrices are the same
-  
-  # Sigma2 <- rep(Sigma[,,1],dim(Sigma)[3])
-  # dim(Sigma2) <- dim(Sigma)
-  # same_mat <- prod(Sigma2 == Sigma)
+  Sigma2 <- rep(Sigma[,,1],dim(Sigma)[3])
+  dim(Sigma2) <- dim(Sigma)
+  same_mat <- prod(Sigma2 == Sigma)
 
 
   ## use the C++ implementation
@@ -425,9 +424,9 @@ dGaussDiscCop2 <- function(x, m, Sigma, eta, log=FALSE, useC=TRUE) {
     x[,seq_len(dim(Sigma)[2] - m)] <- qnorm(x[,seq_len(dim(Sigma)[2] - m)])
 
     ## if all the same matrix, use single copula implementation
-    if (N == 1) {
-      dim(Sigma) <- c(d,d)
-      out <- c(dGDcop2(x, Sigma, trunc=trunc, logd = TRUE))
+    if (same_mat) {
+      Sigma1 <- Sigma[,,1]
+      out <- c(dGDcop2(x = x, sigma = Sigma1, eta = eta, q = m, logd = TRUE))
       if (log) return(out)
       else return(exp(out))
     }

--- a/R/fit.R
+++ b/R/fit.R
@@ -88,7 +88,12 @@ fitCausal <- function(dat, formulas=list(y~x, z~1, ~x),
     wh_cnt <- which(!disc)
     new_ord <- c(wh_cnt, wh_disc, length(forms))
     new_ord0 <- new_ord[-length(new_ord)]
-    dat[inCop] <- dat[inCop][new_ord0]
+    
+    
+    ord <- seq_len(ncol(dat))  
+    ord[match(inCop,names(dat))] <- ord[match(inCop,names(dat))[new_ord0]]
+    dat <- dat[,ord]
+    
     LHS <- LHS[new_ord0]
     forms <- forms[new_ord]
     family <- family[new_ord]

--- a/R/fit.R
+++ b/R/fit.R
@@ -122,7 +122,8 @@ fitCausal <- function(dat, formulas=list(y~x, z~1, ~x),
                       beta = beta_start2$beta_m, phi = beta_start2$phi_m,
                       inCop = seq_along(inCop),
                       fam_cop=fam_cop, fam=family[-length(family)], par2=par2,
-                      useC=useC)
+                      useC=useC,
+                      link = link)
 
   ## parameters to
   maxit <- con$maxit

--- a/R/nll.R
+++ b/R/nll.R
@@ -288,8 +288,20 @@ ll <- function(dat, mm, beta, phi, inCop, fam_cop=1,
           # new_ord <- order(family[inCop])
           dat_u2 <- dat_u[,inCop,drop=FALSE]#[,new_ord,drop=FALSE]
           # Sigma <- Sigma[new_ord,new_ord,,drop=FALSE]
-          # cop <- dGaussDiscCop(dat_u2, Sigma=Sigma, trunc=attr(mm, "trunc"), log=TRUE, useC=useC)
-          cop <- dGaussDiscCop2(dat_u2, m = ndisc, Sigma=Sigma, eta=eta[,inCop,drop=FALSE], log=TRUE, useC=useC)
+          eta2 <- eta
+          # columns of eta that correspond to discrete variables
+          eta_disc <- eta[,(nc - ndisc+1):nc]
+          # link functions that correspond to discrete variables
+          link_disc <- link[(nc - ndisc+1):nc]
+          # which columns to convert
+          eta_disc[,which(link_disc == "logit")] <- qnorm(expit(eta_disc[,which(link_disc == "logit")]))
+          
+          eta2[,(nc - ndisc+1):nc] <- eta_disc
+          
+          # conversion from logit to probit scale
+          # eta2[,(nc - ndisc+1):nc] <- qnorm(expit(eta[,(nc - ndisc+1):nc]))
+          
+          cop <- dGaussDiscCop2(dat_u2, m = ndisc, Sigma=Sigma, eta=eta2[,inCop,drop=FALSE], log=TRUE, useC=useC)
         }
         else cop <- dGaussCop(dat_u[,inCop,drop=FALSE], Sigma=Sigma, log=TRUE, useC=useC)
 

--- a/R/nll.R
+++ b/R/nll.R
@@ -247,8 +247,8 @@ ll <- function(dat, mm, beta, phi, inCop, fam_cop=1,
   for (i in which(family == 5)) {
     # wh_trunc <- wh_trunc + 1
     tmp <- univarDens(dat[,i], eta[,i], family=family[i])
-    # log_den[,i] <- tmp$ld
-    log_den[,i] <- 0 #### CHANGED HERE XI
+    log_den[,i] <- tmp$ld
+    # log_den[,i] <- 0 #### CHANGED HERE XI
     dat_u[,i] <- tmp$u
   }
 

--- a/R/nll.R
+++ b/R/nll.R
@@ -290,7 +290,7 @@ ll <- function(dat, mm, beta, phi, inCop, fam_cop=1,
           # Sigma <- Sigma[new_ord,new_ord,,drop=FALSE]
           eta2 <- eta
           # columns of eta that correspond to discrete variables
-          eta_disc <- eta[,(nc - ndisc+1):nc]
+          eta_disc <- as.matrix(eta[,(nc - ndisc+1):nc])
           # link functions that correspond to discrete variables
           link_disc <- link[(nc - ndisc+1):nc]
           # which columns to convert

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -48,20 +48,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// dGDcop2
-arma::vec dGDcop2(arma::mat const& x, arma::mat const& sigma, Rcpp::List trunc, bool const logd);
-RcppExport SEXP _causl_dGDcop2(SEXP xSEXP, SEXP sigmaSEXP, SEXP truncSEXP, SEXP logdSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< arma::mat const& >::type x(xSEXP);
-    Rcpp::traits::input_parameter< arma::mat const& >::type sigma(sigmaSEXP);
-    Rcpp::traits::input_parameter< Rcpp::List >::type trunc(truncSEXP);
-    Rcpp::traits::input_parameter< bool const >::type logd(logdSEXP);
-    rcpp_result_gen = Rcpp::wrap(dGDcop2(x, sigma, trunc, logd));
-    return rcpp_result_gen;
-END_RCPP
-}
 // dGDcop
 arma::vec dGDcop(arma::mat const& x, arma::mat const& sigma, Rcpp::List trunc, bool const logd);
 RcppExport SEXP _causl_dGDcop(SEXP xSEXP, SEXP sigmaSEXP, SEXP truncSEXP, SEXP logdSEXP) {
@@ -105,15 +91,30 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// dGDcop2
+arma::vec dGDcop2(arma::mat const& x, arma::mat const& sigma, arma::mat const& eta, int q, bool const logd);
+RcppExport SEXP _causl_dGDcop2(SEXP xSEXP, SEXP sigmaSEXP, SEXP etaSEXP, SEXP qSEXP, SEXP logdSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< arma::mat const& >::type x(xSEXP);
+    Rcpp::traits::input_parameter< arma::mat const& >::type sigma(sigmaSEXP);
+    Rcpp::traits::input_parameter< arma::mat const& >::type eta(etaSEXP);
+    Rcpp::traits::input_parameter< int >::type q(qSEXP);
+    Rcpp::traits::input_parameter< bool const >::type logd(logdSEXP);
+    rcpp_result_gen = Rcpp::wrap(dGDcop2(x, sigma, eta, q, logd));
+    return rcpp_result_gen;
+END_RCPP
+}
 
 static const R_CallMethodDef CallEntries[] = {
     {"_causl_g", (DL_FUNC) &_causl_g, 1},
     {"_causl_dGcop", (DL_FUNC) &_causl_dGcop, 3},
     {"_causl_dGcop_sig", (DL_FUNC) &_causl_dGcop_sig, 3},
-    {"_causl_dGDcop2", (DL_FUNC) &_causl_dGDcop2, 4},
     {"_causl_dGDcop", (DL_FUNC) &_causl_dGDcop, 4},
     {"_causl_dGDcop_sig", (DL_FUNC) &_causl_dGDcop_sig, 4},
     {"_causl_dGDcop2_sig", (DL_FUNC) &_causl_dGDcop2_sig, 5},
+    {"_causl_dGDcop2", (DL_FUNC) &_causl_dGDcop2, 5},
     {NULL, NULL, 0}
 };
 

--- a/src/mvgaussDiscCop.cpp
+++ b/src/mvgaussDiscCop.cpp
@@ -714,13 +714,14 @@ arma::vec dGDcop2_sig(arma::mat const &x,
         lower(i,j) = -1e10;
         upper(i,j) = - condmn(i,j)/sqrt(sigma1cov(j,j));
         // XI
-        // marg(i,j) = R::pnorm(- condmn(i,j)/sqrt(sigma1cov(j,j)), 0.0,1.0,1,1);
+        // marg(i,j) = R::pnorm(- eta(i,p + j), 0.0,1.0,1,1);
+        // Rprintf("marg(i,j)) = %i\n", marg(i,j));
       }
       else if (infin(i,j) == 1) {
         lower(i,j) = - condmn(i,j)/sqrt(sigma1cov(j,j));
         upper(i,j) = 1e10;
         // XI
-        // marg(i,j) = R::pnorm(- condmn(i,j)/sqrt(sigma1cov(j,j)), 0.0,1.0,0,1);
+        // marg(i,j) = R::pnorm(- eta(i,p + j), 0.0,1.0,0,1);
         
       }
     }


### PR DESCRIPTION
Changes I've made are:
1. subtract the marginal densities of discrete variables from the copula (instead of from univardens)
2. wrote the function dGDcop2 for when sigma is constant
3. implement a check to determine if sigma is constant (by replicating the first sigma matrix n times and compare the new 3d array with the original sigma 3d array). Call dGDcop2  if constant.