### PR TITLE
Updates to quantiles and vectorized copula computations

### DIFF
--- a/R/families.R
+++ b/R/families.R
@@ -158,7 +158,12 @@ binomial_causl_fam <- function (link) {
   ## write functions
   dens <- function (x, mu, log=FALSE) dbinom(x, size=1, prob=mu, log=log)
   quan <- function (p, mu) qbinom(p, size=1, prob=mu)
-  sim <- function (n, mu) rbinom(n, size=1, prob=mu)
+  sim <- function (n, mu){
+    qx <- runif(n, 0,1)
+    x <- qbinom(qx, size = 1, prob = mu)
+    attr(x, "quantiles") <- qx
+    return(x)
+  }
   probs <- function (x, mu) pbinom(x, size=1, prob=mu)
 
   default <- function(theta) list(x=1, mu=0.5, p=0.5)

--- a/R/sample_data_funcs.R
+++ b/R/sample_data_funcs.R
@@ -200,7 +200,7 @@ link_apply <- function(eta, link, family_nm, inverse = TRUE) {
 ## @inherit glm_sim
 ##'
 ##' @export
-rescale_cop <- function(U, X, beta, family=1, df) {
+rescale_cop <- function(U, X, beta, family=1, df, cdf = FALSE) {
 
   if (!is.matrix(U)) stop("'U' should be a matrix")
   if (!is.matrix(X)) stop("'X' should be a matrix")
@@ -219,25 +219,25 @@ rescale_cop <- function(U, X, beta, family=1, df) {
   }
   else if (family == 2) {
     # Y <- sqrt(phi)*qt(U, df=pars$par2) + eta
-    df <- pars$
+
     param <- 2*expit(eta) - 1
-    Y <- cVCopula(U, copula = tCopula, param = param, par2=df, inverse=TRUE)
+    Y <- cVCopula_fast(U, copula = tCopula, param = param, par2=df, cdf=cdf, inverse=TRUE)
   }
   else if (family == 3) {
     param <- exp(eta) - 1
-    Y <- cVCopula(U, copula = claytonCopula, param = param, inverse=TRUE)
+    Y <- cVCopula_fast(U, copula = claytonCopula, param = param, cdf=cdf, inverse=TRUE)
   }
   else if (family == 4) {
     param <- exp(eta) + 1
-    Y <- cVCopula(U, copula = gumbelCopula, param = param, inverse=TRUE)
+    Y <- cVCopula_fast(U, copula = gumbelCopula, param = param, cdf=cdf, inverse=TRUE)
   }
   else if (family == 5) {
     param <- eta
-    Y <- cVCopula(U, copula = frankCopula, param = param, inverse=TRUE)
+    Y <- cVCopula_fast(U, copula = frankCopula, param = param, cdf=cdf, inverse=TRUE)
   }
   else if (family == 6) {
     param <- exp(eta) + 1
-    Y <- cVCopula(U, copula = joeCopula, param = param, inverse=TRUE)
+    Y <- cVCopula_fast(U, copula = joeCopula, param = param, cdf=cdf, inverse=TRUE)
   }
   else stop("family must be between 0 and 5")
 

--- a/R/sample_data_funcs.R
+++ b/R/sample_data_funcs.R
@@ -213,9 +213,9 @@ rescale_cop <- function(U, X, beta, family=1, df, cdf = FALSE) {
   if (family == 1) {
     # if (link == "tanh")
     param <- 2*expit(eta) - 1
-    # browser()
-    # Y <- cVCopula(U, copula = normalCopula, param = param, inverse=TRUE)
-    Y <- pnorm(qnorm(U[,2])*sqrt(1-param^2)+param*qnorm(U[,1]))
+    # option 2 faster, but need better functionality for inverse and cdf
+    Y <- cVCopula_fast(U, copula = normalCopula, param = param, cdf = cdf,inverse=TRUE)
+    #Y <- pnorm(qnorm(U[,2])*sqrt(1-param^2)+param*qnorm(U[,1]))
   }
   else if (family == 2) {
     # Y <- sqrt(phi)*qt(U, df=pars$par2) + eta
@@ -561,7 +561,8 @@ glm_sim <- function (family, eta, phi, other_pars, link, quantiles=TRUE) {
   else stop("family input should be an integer or 'causl_family' function")
 
   ## return quantile
-  if (is.numeric(family) || !(family$name %in% c("categorical","ordinal"))) {
+  if ((is.numeric(family) || !(family$name %in% c("categorical","ordinal"))) 
+      & is.null(attr(x, "quantile"))) {
     if (quantiles) attr(x, "quantile") <- qx
   }
 


### PR DESCRIPTION
- quantiles in family$rdist now first attach quantiles used to generate deviates. Previously lost lot of information when letting qx <- pbinom(rbinom(.)). 

 - cVCopula_fast gets rid of lapply() in making all the copula objects. Makes as many as is needed then samples from them. Important for survivl simulation technique when we call copulas a lot. 